### PR TITLE
Timeline feature does not respect security constraint set by "add-group-repo" kie-cli command

### DIFF
--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-api/src/main/java/org/kie/uberfire/social/activities/service/SocialSecurityConstraint.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-api/src/main/java/org/kie/uberfire/social/activities/service/SocialSecurityConstraint.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.uberfire.social.activities.service;
+
+import org.kie.uberfire.social.activities.model.SocialActivitiesEvent;
+
+public interface SocialSecurityConstraint {
+
+    boolean hasRestrictions( SocialActivitiesEvent event );
+
+    void init();
+
+}

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCacheClusterPersistence.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCacheClusterPersistence.java
@@ -23,6 +23,7 @@ import com.google.gson.Gson;
 import org.kie.uberfire.social.activities.model.SocialActivitiesEvent;
 import org.kie.uberfire.social.activities.model.SocialEventType;
 import org.kie.uberfire.social.activities.model.SocialUser;
+import org.kie.uberfire.social.activities.security.SocialSecurityConstraintsManager;
 import org.kie.uberfire.social.activities.server.SocialUserServicesExtendedBackEndImpl;
 import org.kie.uberfire.social.activities.service.SocialEventTypeRepositoryAPI;
 import org.kie.uberfire.social.activities.service.SocialTimelinePersistenceAPI;
@@ -43,8 +44,8 @@ public class SocialTimelineCacheClusterPersistence extends SocialTimelineCachePe
                                                   final SocialUserPersistenceAPI socialUserPersistenceAPI,
                                                   final SocialClusterMessaging socialClusterMessaging,
                                                   final SocialUserServicesExtendedBackEndImpl userServicesBackend,
-                                                  final FileSystem fileSystem ) {
-
+                                                  final FileSystem fileSystem,
+                                                  final SocialSecurityConstraintsManager socialSecurityConstraintsManager ) {
         this.gson = gson;
         this.gsonCollectionType = gsonCollectionType;
         this.ioService = ioService;
@@ -53,6 +54,7 @@ public class SocialTimelineCacheClusterPersistence extends SocialTimelineCachePe
         this.socialClusterMessaging = socialClusterMessaging;
         this.userServicesBackend = userServicesBackend;
         this.fileSystem = fileSystem;
+        this.socialSecurityConstraintsManager = socialSecurityConstraintsManager;
         PriorityDisposableRegistry.register( this );
     }
 

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCacheInstancePersistence.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCacheInstancePersistence.java
@@ -23,6 +23,7 @@ import com.google.gson.Gson;
 import org.kie.uberfire.social.activities.model.SocialActivitiesEvent;
 import org.kie.uberfire.social.activities.model.SocialEventType;
 import org.kie.uberfire.social.activities.model.SocialUser;
+import org.kie.uberfire.social.activities.security.SocialSecurityConstraintsManager;
 import org.kie.uberfire.social.activities.server.SocialUserServicesExtendedBackEndImpl;
 import org.kie.uberfire.social.activities.service.SocialEventTypeRepositoryAPI;
 import org.kie.uberfire.social.activities.service.SocialUserPersistenceAPI;
@@ -38,15 +39,16 @@ public class SocialTimelineCacheInstancePersistence extends SocialTimelineCacheP
                                                    final SocialEventTypeRepositoryAPI socialEventTypeRepository,
                                                    final SocialUserPersistenceAPI socialUserService,
                                                    final SocialUserServicesExtendedBackEndImpl userServicesBackend,
-                                                   final FileSystem fileSystem ) {
-
-        this.gson = gson;
+                                                   final FileSystem fileSystem,
+                                                   final SocialSecurityConstraintsManager socialSecurityConstraintsManager ) {
         this.gsonCollectionType = gsonCollectionType;
+        this.gson = gson;
         this.ioService = ioService;
         this.socialEventTypeRepository = socialEventTypeRepository;
         this.socialUserPersistenceAPI = socialUserService;
         this.userServicesBackend = userServicesBackend;
         this.fileSystem = fileSystem;
+        this.socialSecurityConstraintsManager = socialSecurityConstraintsManager;
         PriorityDisposableRegistry.register( this );
     }
 

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCachePersistence.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCachePersistence.java
@@ -26,6 +26,7 @@ import com.google.gson.Gson;
 import org.kie.uberfire.social.activities.model.SocialActivitiesEvent;
 import org.kie.uberfire.social.activities.model.SocialEventType;
 import org.kie.uberfire.social.activities.model.SocialUser;
+import org.kie.uberfire.social.activities.security.SocialSecurityConstraintsManager;
 import org.kie.uberfire.social.activities.server.SocialUserServicesExtendedBackEndImpl;
 import org.kie.uberfire.social.activities.service.SocialEventTypeRepositoryAPI;
 import org.kie.uberfire.social.activities.service.SocialTimelinePersistenceAPI;
@@ -59,6 +60,9 @@ public abstract class SocialTimelineCachePersistence implements SocialTimelinePe
     SocialUserPersistenceAPI socialUserPersistenceAPI;
 
     SocialUserServicesExtendedBackEndImpl userServicesBackend;
+
+    SocialSecurityConstraintsManager socialSecurityConstraintsManager;
+
 
     @Override
     public void setup() {
@@ -99,20 +103,24 @@ public abstract class SocialTimelineCachePersistence implements SocialTimelinePe
             } else {
                 createPersistenceStructure( timelineDir );
             }
-            return events;
+            return applySocialSecurityConstraints( events );
         } catch ( Exception e ) {
             throw new ErrorAccessingTimeline( e );
         }
     }
 
-    private List<SocialActivitiesEvent> getTimeline( Path timelineDir,
+    List<SocialActivitiesEvent> getTimeline( Path timelineDir,
                                                      String fileIndex ) {
         List<SocialActivitiesEvent> events;
         Path fileTimeline = timelineDir.resolve( fileIndex );
         String numberOfEvents = getItemsMetadata( timelineDir, fileIndex );
-        SocialFile socialFile = new SocialFile( fileTimeline, ioService, gson );
+        SocialFile socialFile = createSocialFile( fileTimeline );
         events = socialFile.readSocialEvents( Integer.valueOf( numberOfEvents ) );
-        return events;
+        return applySocialSecurityConstraints( events );
+    }
+
+    SocialFile createSocialFile( Path fileTimeline ) {
+        return new SocialFile( fileTimeline, ioService, gson );
     }
 
     private boolean thereIsSomethingToRead( Integer lastFileIndex ) {
@@ -130,7 +138,7 @@ public abstract class SocialTimelineCachePersistence implements SocialTimelinePe
         return lastIndex;
     }
 
-    private void createPersistenceStructure( Path timelineDir ) {
+    void createPersistenceStructure( Path timelineDir ) {
         String lastIndex = "-1";
         updateLastIndexFile( timelineDir, lastIndex );
     }
@@ -175,7 +183,7 @@ public abstract class SocialTimelineCachePersistence implements SocialTimelinePe
         }
     }
 
-    private String getItemsMetadata( Path timeLineDir,
+    String getItemsMetadata( Path timeLineDir,
                                      String originalFilename ) {
         String metadataFileName = originalFilename + Constants.METADATA;
         Path timelineFile = timeLineDir.resolve( metadataFileName );
@@ -246,9 +254,8 @@ public abstract class SocialTimelineCachePersistence implements SocialTimelinePe
     }
 
     enum Constants {
-        LAST_FILE_INDEX, USER_TIMELINE, METADATA
+        LAST_FILE_INDEX, USER_TIMELINE, METADATA;
     }
-
     //TYPE STUFF
 
     List<SocialActivitiesEvent> createOrGetTypeTimeline( SocialEventType type ) {
@@ -258,10 +265,10 @@ public abstract class SocialTimelineCachePersistence implements SocialTimelinePe
 
     @Override
     public List<SocialActivitiesEvent> getLastEvents( SocialEventType key ) {
-        List<SocialActivitiesEvent> socialActivitiesEvents = new ArrayList<SocialActivitiesEvent>();
-        socialActivitiesEvents.addAll( typeEventsTimelineCache.get( key ) );
-        socialActivitiesEvents.addAll( typeEventsFreshEvents.get( key ) );
-        return socialActivitiesEvents;
+        List<SocialActivitiesEvent> events = new ArrayList<SocialActivitiesEvent>();
+        events.addAll( typeEventsTimelineCache.get( key ) );
+        events.addAll( typeEventsFreshEvents.get( key ) );
+        return applySocialSecurityConstraints( events );
     }
 
     List<SocialActivitiesEvent> storeTimeLineInFile( SocialEventType type ) {
@@ -293,12 +300,12 @@ public abstract class SocialTimelineCachePersistence implements SocialTimelinePe
 
     @Override
     public List<SocialActivitiesEvent> getRecentEvents( SocialEventType type ) {
-        List<SocialActivitiesEvent> socialActivitiesEvents = new ArrayList<SocialActivitiesEvent>();
+        List<SocialActivitiesEvent> events = new ArrayList<SocialActivitiesEvent>();
         List<SocialActivitiesEvent> typeEvents = typeEventsFreshEvents.get( type );
         if ( typeEvents != null ) {
-            socialActivitiesEvents.addAll( typeEvents );
+            events.addAll( typeEvents );
         }
-        return socialActivitiesEvents;
+        return applySocialSecurityConstraints( events );
     }
 
     @Override
@@ -321,7 +328,6 @@ public abstract class SocialTimelineCachePersistence implements SocialTimelinePe
     Map<String, List<SocialActivitiesEvent>> userEventsTimelineCache = new HashMap<String, List<SocialActivitiesEvent>>();
     Map<String, List<SocialActivitiesEvent>> userEventsTimelineFreshEvents = new HashMap<String, List<SocialActivitiesEvent>>();
     Map<String, SocialCacheControl> userEventsCacheControl = new HashMap<String, SocialCacheControl>();
-
     List<SocialActivitiesEvent> createOrGetUserTimeline( String userName ) {
         return createOrGetTimeline( getRootUserTimelineDirectory().resolve( userName ) );
     }
@@ -350,7 +356,7 @@ public abstract class SocialTimelineCachePersistence implements SocialTimelinePe
         }
         socialActivitiesEvents.addAll( userEventsTimelineCache.get( user.getUserName() ) );
         socialActivitiesEvents.addAll( userEventsTimelineFreshEvents.get( user.getUserName() ) );
-        return socialActivitiesEvents;
+        return applySocialSecurityConstraints( socialActivitiesEvents );
     }
 
     @Override
@@ -361,7 +367,7 @@ public abstract class SocialTimelineCachePersistence implements SocialTimelinePe
             createCacheStructureForNewUsers( user );
         }
         socialActivitiesEvents.addAll( userEventsTimelineFreshEvents.get( user.getUserName() ) );
-        return socialActivitiesEvents;
+        return applySocialSecurityConstraints( socialActivitiesEvents );
     }
 
     private void createCacheStructureForNewUsers( SocialUser user ) {
@@ -452,5 +458,9 @@ public abstract class SocialTimelineCachePersistence implements SocialTimelinePe
     @Override
     public void dispose() {
         saveAllEvents();
+    }
+
+    private List<SocialActivitiesEvent> applySocialSecurityConstraints( List<SocialActivitiesEvent> events ) {
+        return socialSecurityConstraintsManager.applyConstraints(events);
     }
 }

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/security/SocialSecurityConstraintsManager.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/security/SocialSecurityConstraintsManager.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.uberfire.social.activities.security;
+
+import org.kie.uberfire.social.activities.model.SocialActivitiesEvent;
+import org.kie.uberfire.social.activities.service.SocialSecurityConstraint;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@ApplicationScoped
+public class SocialSecurityConstraintsManager {
+
+
+    @Inject
+    private Instance<SocialSecurityConstraint> socialSecurityConstraints;
+
+
+    public List<SocialActivitiesEvent> applyConstraints( List<SocialActivitiesEvent> events ) {
+        List<SocialActivitiesEvent> secureEvents = new ArrayList<SocialActivitiesEvent>();
+
+        initConstraints();
+
+        for ( SocialActivitiesEvent event : events ) {
+            if ( isAllowed( event ) ) {
+                secureEvents.add( event );
+            }
+        }
+
+        return secureEvents;
+    }
+
+    private void initConstraints() {
+        for ( SocialSecurityConstraint securityConstraint : getSocialSecurityConstraints() ) {
+            securityConstraint.init();
+        }
+    }
+
+    private boolean isAllowed( SocialActivitiesEvent event ) {
+        for ( SocialSecurityConstraint securityConstraint : getSocialSecurityConstraints() ) {
+            if ( securityConstraint.hasRestrictions( event ) ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    Instance<SocialSecurityConstraint> getSocialSecurityConstraints() {
+        return socialSecurityConstraints;
+    }
+}

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/server/SocialTimelinePersistenceProducer.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/server/SocialTimelinePersistenceProducer.java
@@ -31,6 +31,7 @@ import org.kie.uberfire.social.activities.model.SocialActivitiesEvent;
 import org.kie.uberfire.social.activities.persistence.SocialClusterMessaging;
 import org.kie.uberfire.social.activities.persistence.SocialTimelineCacheClusterPersistence;
 import org.kie.uberfire.social.activities.persistence.SocialTimelineCacheInstancePersistence;
+import org.kie.uberfire.social.activities.security.SocialSecurityConstraintsManager;
 import org.kie.uberfire.social.activities.service.SocialEventTypeRepositoryAPI;
 import org.kie.uberfire.social.activities.service.SocialTimelinePersistenceAPI;
 import org.kie.uberfire.social.activities.service.SocialUserPersistenceAPI;
@@ -74,13 +75,16 @@ public class SocialTimelinePersistenceProducer {
     @Inject
     private SocialUserPersistenceAPI socialUserPersistenceAPI;
 
+    @Inject
+    SocialSecurityConstraintsManager socialSecurityConstraintsManager;
+
     @PostConstruct
     public void setup() {
         gsonFactory();
         if ( clusterServiceFactory == null ) {
-            socialTimelinePersistenceAPI = new SocialTimelineCacheInstancePersistence( gson, gsonCollectionType, ioService, socialEventTypeRepository, socialUserPersistenceAPI, userServicesBackend, fileSystem );
+            socialTimelinePersistenceAPI = new SocialTimelineCacheInstancePersistence( gson, gsonCollectionType, ioService, socialEventTypeRepository, socialUserPersistenceAPI, userServicesBackend, fileSystem, socialSecurityConstraintsManager );
         } else {
-            socialTimelinePersistenceAPI = new SocialTimelineCacheClusterPersistence( gson, gsonCollectionType, ioService, socialEventTypeRepository, socialUserPersistenceAPI, socialClusterMessaging, userServicesBackend, fileSystem );
+            socialTimelinePersistenceAPI = new SocialTimelineCacheClusterPersistence( gson, gsonCollectionType, ioService, socialEventTypeRepository, socialUserPersistenceAPI, socialClusterMessaging, userServicesBackend, fileSystem, socialSecurityConstraintsManager );
         }
         socialTimelinePersistenceAPI.setup();
     }

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/test/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCacheClusterPersistenceTest.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/test/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCacheClusterPersistenceTest.java
@@ -9,7 +9,7 @@ public class SocialTimelineCacheClusterPersistenceTest {
 
     @Test
     public void testDisposableRegistry() {
-        final SocialTimelineCacheClusterPersistence object = new SocialTimelineCacheClusterPersistence( null, null, null, null, null, null, null, null );
+        final SocialTimelineCacheClusterPersistence object = new SocialTimelineCacheClusterPersistence( null, null, null, null, null, null, null, null, null );
         assertTrue( PriorityDisposableRegistry.getDisposables().contains( object ) );
     }
 

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/test/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCacheInstancePersistenceTest.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/test/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCacheInstancePersistenceTest.java
@@ -3,16 +3,16 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
-
+ */
 package org.kie.uberfire.social.activities.persistence;
 
 import org.junit.Before;

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/test/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCacheInstancePersistenceUnitTestWrapper.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/test/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCacheInstancePersistenceUnitTestWrapper.java
@@ -26,20 +26,26 @@ import org.kie.uberfire.social.activities.model.SocialActivitiesEvent;
 import org.kie.uberfire.social.activities.model.SocialEventType;
 import org.kie.uberfire.social.activities.model.SocialUser;
 import org.kie.uberfire.social.activities.repository.SocialEventTypeRepository;
+import org.kie.uberfire.social.activities.security.SocialSecurityConstraintsManager;
 import org.uberfire.io.IOService;
 
 public class SocialTimelineCacheInstancePersistenceUnitTestWrapper extends SocialTimelineCacheInstancePersistence {
 
     public SocialTimelineCacheInstancePersistenceUnitTestWrapper() {
-        super( null, null, null, null, null, null, null );
+        super( null, null, null, null, null, null, null, null );
     }
+
+    public SocialTimelineCacheInstancePersistenceUnitTestWrapper(SocialSecurityConstraintsManager socialSecurityConstraintsManager) {
+        super( null, null, null, null, null, null, null, socialSecurityConstraintsManager );
+    }
+
 
     public SocialTimelineCacheInstancePersistenceUnitTestWrapper( Gson gson,
                                                                   Type gsonCollectionType,
                                                                   IOService ioService,
                                                                   SocialEventTypeRepository socialEventTypeRepository,
                                                                   SocialUserClusterPersistence socialUserService ) {
-        super( gson, gsonCollectionType, ioService, socialEventTypeRepository, socialUserService, null, null );
+        super( gson, gsonCollectionType, ioService, socialEventTypeRepository, socialUserService, null, null, null );
     }
 
     @Override

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/test/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCachePersistenceTest.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/test/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCachePersistenceTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.uberfire.social.activities.persistence;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.uberfire.social.activities.model.SocialActivitiesEvent;
+import org.kie.uberfire.social.activities.model.SocialEventType;
+import org.kie.uberfire.social.activities.model.SocialUser;
+import org.kie.uberfire.social.activities.security.SocialSecurityConstraintsManager;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Path;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class SocialTimelineCachePersistenceTest {
+
+
+    private SocialTimelineCachePersistence socialTimelineCachePersistence;
+    private SocialSecurityConstraintsManager socialSecurityConstraintsManager;
+    private List<SocialActivitiesEvent> oneEventList = new ArrayList<SocialActivitiesEvent>();
+
+    @Before
+    public void setUp() throws Exception {
+        socialTimelineCachePersistence = createFakeSocialTimelineCachePersistence();
+        this.socialSecurityConstraintsManager = mock( SocialSecurityConstraintsManager.class );
+        socialTimelineCachePersistence.socialSecurityConstraintsManager = socialSecurityConstraintsManager;
+        oneEventList.add( new SocialActivitiesEvent() );
+    }
+
+
+    @Test
+    public void getLastEventsShouldCallSocialConstraintsManagerTest() throws Exception {
+        final SocialEventType type = mock( SocialEventType.class );
+        socialTimelineCachePersistence.typeEventsTimelineCache.put( type, oneEventList );
+        socialTimelineCachePersistence.typeEventsFreshEvents.put( type, oneEventList );
+        socialTimelineCachePersistence.getLastEvents( type );
+
+        verify( socialSecurityConstraintsManager ).applyConstraints( any( List.class ) );
+    }
+
+    @Test
+    public void getRecentEventsShouldCallSocialConstraintsManagerTest() throws Exception {
+        socialTimelineCachePersistence.getRecentEvents( mock( SocialEventType.class ) );
+
+        verify( socialSecurityConstraintsManager ).applyConstraints( any( List.class ) );
+    }
+
+    @Test
+    public void getLastUserEventsShouldCallSocialConstraintsManagerTest() throws Exception {
+        final SocialUser user = new SocialUser( "dora" );
+        socialTimelineCachePersistence.userEventsTimelineCache.put( user.getUserName(), oneEventList );
+        socialTimelineCachePersistence.userEventsTimelineFreshEvents.put( user.getUserName(), oneEventList );
+        socialTimelineCachePersistence.getLastEvents( user );
+
+        verify( socialSecurityConstraintsManager ).applyConstraints( any( List.class ) );
+    }
+
+    @Test
+    public void getUserRecentEventsShouldCallSocialConstraintsManagerTest() throws Exception {
+        final SocialUser user = new SocialUser( "dora" );
+        socialTimelineCachePersistence.userEventsTimelineCache.put( user.getUserName(), oneEventList );
+        socialTimelineCachePersistence.userEventsTimelineFreshEvents.put( user.getUserName(), oneEventList );
+        socialTimelineCachePersistence.getRecentEvents( user );
+
+        verify( socialSecurityConstraintsManager ).applyConstraints( any( List.class ) );
+    }
+
+    @Test
+    public void createOrGetTimelineShouldCallSocialConstraintsManagerTest() throws Exception {
+
+        socialTimelineCachePersistence.createOrGetTimeline( mock( Path.class ) );
+
+        verify( socialSecurityConstraintsManager ).applyConstraints( any( List.class ) );
+    }
+
+    @Test
+    public void getTimelineShouldCallSocialConstraintsManagerTest() throws Exception {
+        socialTimelineCachePersistence.getTimeline( mock( Path.class ), "" );
+
+        verify( socialSecurityConstraintsManager ).applyConstraints( any( List.class ) );
+    }
+
+    private SocialTimelineCachePersistence createFakeSocialTimelineCachePersistence() {
+        return new SocialTimelineCachePersistence() {
+
+            @Override
+            public void persist( SocialActivitiesEvent event ) {
+
+            }
+
+            @Override
+            public void persist( SocialUser user, SocialActivitiesEvent event ) {
+
+            }
+
+            @Override
+            public void saveAllEvents() {
+
+            }
+
+            @Override
+            IOService getIoService() {
+                final IOService mock = mock( IOService.class );
+                when( mock.exists( any( Path.class ) ) ).thenReturn( false );
+                return mock;
+            }
+
+            @Override
+            void createPersistenceStructure( Path timelineDir ) {
+            }
+
+            @Override
+            String getItemsMetadata( Path timeLineDir, String originalFilename ) {
+                return "-1";
+            }
+
+            @Override
+            SocialFile createSocialFile( Path fileTimeline ) {
+                return mock( SocialFile.class );
+            }
+        };
+    }
+}

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/test/java/org/kie/uberfire/social/activities/repository/SocialTypeTimelinePagedRepositoryTest.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/test/java/org/kie/uberfire/social/activities/repository/SocialTypeTimelinePagedRepositoryTest.java
@@ -15,33 +15,39 @@
 
 package org.kie.uberfire.social.activities.repository;
 
-import java.util.Date;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
-import org.kie.uberfire.social.activities.model.DefaultTypes;
-import org.kie.uberfire.social.activities.model.PagedSocialQuery;
-import org.kie.uberfire.social.activities.model.SocialActivitiesEvent;
-import org.kie.uberfire.social.activities.model.SocialEventType;
-import org.kie.uberfire.social.activities.model.SocialPaged;
-import org.kie.uberfire.social.activities.model.SocialUser;
+import org.kie.uberfire.social.activities.model.*;
 import org.kie.uberfire.social.activities.persistence.SocialTimelineCacheInstancePersistenceUnitTestWrapper;
+import org.kie.uberfire.social.activities.security.SocialSecurityConstraintsManager;
 import org.kie.uberfire.social.activities.service.SocialAdapter;
 import org.kie.uberfire.social.activities.service.SocialCommandTypeFilter;
 import org.kie.uberfire.social.activities.service.SocialTimelinePersistenceAPI;
 
-import static org.junit.Assert.*;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
 
 public class SocialTypeTimelinePagedRepositoryTest {
 
     private SocialTypeTimelinePagedRepository repository;
     private SocialEventType type = DefaultTypes.DUMMY_EVENT;
     private SocialTimelinePersistenceAPI socialTimelinePersistenceFake;
+    private SocialSecurityConstraintsManager socialSecurityConstraintsManagerSpy;
 
     @Before
     public void setUp() throws Exception {
-        socialTimelinePersistenceFake = new SocialTimelineCacheInstancePersistenceUnitTestWrapper();
+        SocialSecurityConstraintsManager socialSecurityConstraintsManager = new SocialSecurityConstraintsManager() {
+            @Override
+            public List<SocialActivitiesEvent> applyConstraints( List<SocialActivitiesEvent> events ) {
+                return events;
+            }
+        };
+        socialSecurityConstraintsManagerSpy = spy( socialSecurityConstraintsManager );
+        socialTimelinePersistenceFake = new SocialTimelineCacheInstancePersistenceUnitTestWrapper( socialSecurityConstraintsManagerSpy );
         repository = new SocialTypeTimelinePagedRepository() {
 
             @Override
@@ -142,6 +148,8 @@ public class SocialTypeTimelinePagedRepositoryTest {
         assertTrue( query.socialEvents().size() == 3 );
         assertTrue( !socialPaged.canIGoForward() );
 
+        verify( socialSecurityConstraintsManagerSpy ).applyConstraints( any( List.class ) );
+
     }
 
     private void assertStoredEvent( String fileName,
@@ -150,13 +158,13 @@ public class SocialTypeTimelinePagedRepositoryTest {
                                     List<SocialActivitiesEvent> events ) {
         SocialActivitiesEvent event = events.get( index );
         assertEquals( fileName, event.getSocialUser().getUserName() );
-        assertEquals( expected, event.getAdditionalInfo()[ 0 ] );
+        assertEquals( expected, event.getAdditionalInfo()[0] );
     }
 
     private void assertFreshEvents( PagedSocialQuery query ) {
-        assertEquals( "2", query.socialEvents().get( 0 ).getAdditionalInfo()[ 0 ] );
-        assertEquals( "1", query.socialEvents().get( 1 ).getAdditionalInfo()[ 0 ] );
-        assertEquals( "0", query.socialEvents().get( 2 ).getAdditionalInfo()[ 0 ] );
+        assertEquals( "2", query.socialEvents().get( 0 ).getAdditionalInfo()[0] );
+        assertEquals( "1", query.socialEvents().get( 1 ).getAdditionalInfo()[0] );
+        assertEquals( "0", query.socialEvents().get( 2 ).getAdditionalInfo()[0] );
     }
 
     private PagedSocialQuery queryAndAssertNumberOfEvents( int numberOfEvents,

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/test/java/org/kie/uberfire/social/activities/repository/SocialUserTimelinePagedRepositoryTest.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/test/java/org/kie/uberfire/social/activities/repository/SocialUserTimelinePagedRepositoryTest.java
@@ -15,20 +15,19 @@
 
 package org.kie.uberfire.social.activities.repository;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.uberfire.social.activities.model.*;
+import org.kie.uberfire.social.activities.persistence.SocialTimelineCacheInstancePersistenceUnitTestWrapper;
+import org.kie.uberfire.social.activities.security.SocialSecurityConstraintsManager;
+import org.kie.uberfire.social.activities.service.SocialTimelinePersistenceAPI;
+
 import java.util.Date;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.kie.uberfire.social.activities.model.DefaultTypes;
-import org.kie.uberfire.social.activities.model.PagedSocialQuery;
-import org.kie.uberfire.social.activities.model.SocialActivitiesEvent;
-import org.kie.uberfire.social.activities.model.SocialPaged;
-import org.kie.uberfire.social.activities.model.SocialUser;
-import org.kie.uberfire.social.activities.persistence.SocialTimelineCacheInstancePersistenceUnitTestWrapper;
-import org.kie.uberfire.social.activities.service.SocialTimelinePersistenceAPI;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class SocialUserTimelinePagedRepositoryTest {
 
@@ -38,7 +37,14 @@ public class SocialUserTimelinePagedRepositoryTest {
 
     @Before
     public void setUp() throws Exception {
-        socialTimelinePersistenceFake = new SocialTimelineCacheInstancePersistenceUnitTestWrapper();
+        SocialSecurityConstraintsManager socialSecurityConstraintsManager = new SocialSecurityConstraintsManager(){
+            @Override
+            public List<SocialActivitiesEvent> applyConstraints( List<SocialActivitiesEvent> events ) {
+                return events;
+            }
+        };
+
+        socialTimelinePersistenceFake = new SocialTimelineCacheInstancePersistenceUnitTestWrapper( socialSecurityConstraintsManager );
         repository = new SocialUserTimelinePagedRepository() {
             @Override
             SocialTimelinePersistenceAPI getSocialTimelinePersistenceAPI() {
@@ -204,13 +210,13 @@ public class SocialUserTimelinePagedRepositoryTest {
                                     List<SocialActivitiesEvent> events ) {
         SocialActivitiesEvent event = events.get( index );
         assertEquals( fileName, event.getSocialUser().getUserName() );
-        assertEquals( expected, event.getAdditionalInfo()[ 0 ] );
+        assertEquals( expected, event.getAdditionalInfo()[0] );
     }
 
     private void assertFreshEvents( PagedSocialQuery query ) {
-        assertEquals( "2", query.socialEvents().get( 0 ).getAdditionalInfo()[ 0 ] );
-        assertEquals( "1", query.socialEvents().get( 1 ).getAdditionalInfo()[ 0 ] );
-        assertEquals( "0", query.socialEvents().get( 2 ).getAdditionalInfo()[ 0 ] );
+        assertEquals( "2", query.socialEvents().get( 0 ).getAdditionalInfo()[0] );
+        assertEquals( "1", query.socialEvents().get( 1 ).getAdditionalInfo()[0] );
+        assertEquals( "0", query.socialEvents().get( 2 ).getAdditionalInfo()[0] );
     }
 
     @Test
@@ -220,13 +226,13 @@ public class SocialUserTimelinePagedRepositoryTest {
 
         SocialPaged socialPaged = new SocialPaged( 1 );
         PagedSocialQuery query = repository.getUserTimeline( socialUser, socialPaged );
-        assertEquals( "2", query.socialEvents().get( 0 ).getAdditionalInfo()[ 0 ] );
+        assertEquals( "2", query.socialEvents().get( 0 ).getAdditionalInfo()[0] );
 
         query = repository.getUserTimeline( socialUser, socialPaged );
-        assertEquals( "1", query.socialEvents().get( 0 ).getAdditionalInfo()[ 0 ] );
+        assertEquals( "1", query.socialEvents().get( 0 ).getAdditionalInfo()[0] );
 
         query = repository.getUserTimeline( socialUser, socialPaged );
-        assertEquals( "0", query.socialEvents().get( 0 ).getAdditionalInfo()[ 0 ] );
+        assertEquals( "0", query.socialEvents().get( 0 ).getAdditionalInfo()[0] );
 
     }
 
@@ -274,7 +280,7 @@ public class SocialUserTimelinePagedRepositoryTest {
 
     private void createFreshCacheEventsEvents( int numberOfEvents ) {
         for ( int i = 0; i < numberOfEvents; i++ ) {
-            socialTimelinePersistenceFake.persist( socialUser, new SocialActivitiesEvent( new SocialUser( "fresh" ), DefaultTypes.DUMMY_EVENT, new Date()).withAdicionalInfo(  i + "" ) );
+            socialTimelinePersistenceFake.persist( socialUser, new SocialActivitiesEvent( new SocialUser( "fresh" ), DefaultTypes.DUMMY_EVENT, new Date() ).withAdicionalInfo( i + "" ) );
         }
     }
 }

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/test/java/org/kie/uberfire/social/activities/security/SocialSecurityConstraintsManagerTest.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/test/java/org/kie/uberfire/social/activities/security/SocialSecurityConstraintsManagerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.uberfire.social.activities.security;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.uberfire.social.activities.model.SocialActivitiesEvent;
+import org.kie.uberfire.social.activities.model.SocialUser;
+import org.kie.uberfire.social.activities.service.SocialSecurityConstraint;
+
+import javax.enterprise.inject.Instance;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class SocialSecurityConstraintsManagerTest {
+
+    private SocialSecurityConstraintsManager socialSecurityConstraintsManager;
+    private List<SocialActivitiesEvent> events;
+    private SocialActivitiesEvent event1;
+    private SocialActivitiesEvent event2;
+    private Instance securityConstraints;
+    private SocialSecurityConstraint constraint1;
+    private SocialSecurityConstraint constraint2;
+
+
+    @Before
+    public void setup() {
+        securityConstraints = mock( Instance.class );
+        event1 = generateEvent( new SocialUser( "admin" ) );
+        event2 = generateEvent( new SocialUser( "dora" ) );
+        events = new ArrayList<SocialActivitiesEvent>();
+        events.add( event1 );
+        events.add( event2 );
+        constraint1 = mock( SocialSecurityConstraint.class );
+        constraint2 = mock( SocialSecurityConstraint.class );
+        when( securityConstraints.iterator() ).thenReturn( createSecurityConstraintsIterator() );
+        socialSecurityConstraintsManager = new SocialSecurityConstraintsManager() {
+            @Override
+            Instance<SocialSecurityConstraint> getSocialSecurityConstraints() {
+                Instance<SocialSecurityConstraint> mock = mock( Instance.class );
+                when( mock.iterator() ).thenReturn( createSecurityConstraintsIterator() );
+                return mock;
+            }
+        };
+    }
+
+    @Test
+    public void applyConstraintsTest() throws Exception {
+        final List<SocialActivitiesEvent> secureEvents = socialSecurityConstraintsManager.applyConstraints( events );
+        verify( constraint1 ).init();
+        verify( constraint2 ).init();
+        assertEquals( events.size(), secureEvents.size() );
+    }
+
+    @Test
+    public void applyConstraintsWithRestrictionTest() throws Exception {
+        when( constraint2.hasRestrictions( event1 ) ).thenReturn( true );
+
+        final List<SocialActivitiesEvent> secureEvents = socialSecurityConstraintsManager.applyConstraints( events );
+        assertEquals( 1, secureEvents.size() );
+        assertEquals( event2, secureEvents.get( 0 ) );
+    }
+
+    private Iterator<SocialSecurityConstraint> createSecurityConstraintsIterator() {
+        List<SocialSecurityConstraint> list = new ArrayList<SocialSecurityConstraint>();
+        list.add( constraint1 );
+        list.add( constraint2 );
+        return list.iterator();
+    }
+
+    private SocialActivitiesEvent generateEvent( SocialUser user ) {
+        return new SocialActivitiesEvent(
+                user, "", new Date() );
+    }
+}


### PR DESCRIPTION
Problem
------------
kie-config-cli can restrict access to the git repository/organization unit only for user with specific group. 

However, when a user - not a member of this group - displays the Home -> Timeline feature - he is still able to open & edit & save assets which are located in a protected git repository.

Solution
------------
In order to address this issue, I've to create a new plugabble security mechanism on kie-uberfire-extensions.
That mechanism includes a [SocialSecurityConstraintsManager](https://github.com/ederign/kie-uberfire-extensions/blob/ceb4e3a49f90c9f56e8c7818d43d85cc1bccb97c/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/security/SocialSecurityConstraintsManager.java)  that look for cdi implementations of [SocialSecurityConstraint](https://github.com/ederign/kie-uberfire-extensions/blob/ceb4e3a49f90c9f56e8c7818d43d85cc1bccb97c/kie-uberfire-social-activities/kie-uberfire-social-activities-api/src/main/java/org/kie/uberfire/social/activities/service/SocialSecurityConstraint.java) and apply this constraints to a list of social events.

[SocialSecurityConstraint](https://github.com/ederign/kie-uberfire-extensions/blob/ceb4e3a49f90c9f56e8c7818d43d85cc1bccb97c/kie-uberfire-social-activities/kie-uberfire-social-activities-api/src/main/java/org/kie/uberfire/social/activities/service/SocialSecurityConstraint.java)  has two methods, hasRestrictions that see if there is some restrictions for a given event, and init methods that is called before hasRestrictions in order to build some cache (if necessary).

Each [SocialTimelineCachePersistence](https://github.com/ederign/kie-uberfire-extensions/blob/ceb4e3a49f90c9f56e8c7818d43d85cc1bccb97c/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/persistence/SocialTimelineCachePersistence.java) that returns a timeline instead of returning events are now calling applySocialSecurityConstraints method that delegates to [SocialSecurityConstraintsManager](https://github.com/ederign/kie-uberfire-extensions/blob/ceb4e3a49f90c9f56e8c7818d43d85cc1bccb97c/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/security/SocialSecurityConstraintsManager.java).


The implementation of [SocialSecurityConstraint](https://github.com/ederign/kie-uberfire-extensions/blob/ceb4e3a49f90c9f56e8c7818d43d85cc1bccb97c/kie-uberfire-social-activities/kie-uberfire-social-activities-api/src/main/java/org/kie/uberfire/social/activities/service/SocialSecurityConstraint.java)  are located on kie-wb-common home page:

- [SocialEventOUConstraint](https://github.com/ederign/kie-wb-common/blob/8f071c1b9da2e42138456c02fad11b748be7d313/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-backend/src/main/java/org/kie/workbench/common/screens/social/hp/security/SocialEventOUConstraint.java) that secures a event againts OU restrictions;
- [SocialEventRepositoryConstraint](https://github.com/ederign/kie-wb-common/blob/8f071c1b9da2e42138456c02fad11b748be7d313/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-backend/src/main/java/org/kie/workbench/common/screens/social/hp/security/SocialEventRepositoryConstraint.java) that secures a project/asset event agains repositories permissions.


I also found and fix another feature leak issue related to link creations on Social Timelines. If a user has a permission to create a asset sometime, had created a asset and then lost the authoring permission, the links are still created and our user can assets AuthoringPerspective via social link. That was fixed in [DefaultSocialLinkCommandGenerator](https://github.com/ederign/kie-wb-common/blob/8f071c1b9da2e42138456c02fad11b748be7d313/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-client/src/main/java/org/kie/workbench/common/screens/social/hp/client/homepage/DefaultSocialLinkCommandGenerator.java).


Child PR
------------
https://github.com/droolsjbpm/kie-wb-common/pull/132