### PR TITLE
Remove import of uberfire-parent-with-dependencies

### DIFF
--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-client/pom.xml
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-client/pom.xml
@@ -14,18 +14,6 @@
   <name>KIE Uberfire Social Activities Client</name>
   <description>KIE Uberfire Social Activities Client</description>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-parent-with-dependencies</artifactId>
-        <type>pom</type>
-        <version>${version.org.uberfire}</version>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <!-- Project Dependencies -->
 


### PR DESCRIPTION
This really can not be there. It may override versions coming from kie-platform-bom, but only locally for that particular artifact. Those won't be used later (e.g. when building kie-wb). This may lead to very subtle and hard to find bugs.