### PR TITLE
[DROOLS-1216] exclude commons-logging and use jcl-over-slf4j instead

### DIFF
--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/pom.xml
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/pom.xml
@@ -23,6 +23,18 @@
     <dependency>
       <groupId>org.apache.abdera</groupId>
       <artifactId>abdera-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Replacement for the above excluded 'commons-logging:commons-logging' -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -114,6 +126,12 @@
       <groupId>org.apache.abdera</groupId>
       <artifactId>abdera-server</artifactId>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
Part of an ensemble:
https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/226
https://github.com/droolsjbpm/drools/pull/815
https://github.com/droolsjbpm/optaplanner/pull/200
https://github.com/droolsjbpm/jbpm/pull/487
https://github.com/droolsjbpm/droolsjbpm-integration/pull/509
https://github.com/droolsjbpm/kie-uberfire-extensions/pull/29
https://github.com/droolsjbpm/guvnor/pull/328
https://github.com/droolsjbpm/drools-wb/pull/209
https://github.com/droolsjbpm/jbpm-designer/pull/302
https://github.com/droolsjbpm/jbpm-console-ng/pull/432
https://github.com/droolsjbpm/kie-wb-distributions/pull/303
